### PR TITLE
Bugfix bootstrap + warning message about safe sources

### DIFF
--- a/WME P2SM.user.js
+++ b/WME P2SM.user.js
@@ -40,33 +40,6 @@ var p2sm_version = "2021.04.02.02";
 /*global firstProj*/
 /*global newtab*/
 
-if (typeof __RTLM_PAGE_SCOPE_RUN__ === typeof undefined) {
-  (function page_scope_runner()
-   {
-    // If we're _not_ already running in the page, grab the full source
-    // of this script.
-    var my_src = "(" + page_scope_runner.caller.toString() + ")();";
-
-    // Create a script node holding this script, plus a marker that lets us
-    // know we are running in the page scope (not the Greasemonkey sandbox).
-    // Note that we are intentionally *not* scope-wrapping here.
-    var script = document.createElement('script');
-    script.setAttribute("type", "text/javascript");
-    script.textContent = "var __RTLM_PAGE_SCOPE_RUN__ = true;\n" + my_src;
-
-    // Insert the script node into the page, so it will run, and immediately
-    // remove it to clean up.  Use setTimeout to force execution "outside" of
-    // the user script scope completely.
-    setTimeout(function() {
-          document.body.appendChild(script);
-          add_buttons();
-        }, 3000);
-  })();
-
-  // Stop running, because we know Greasemonkey actually runs us in
-  // an anonymous wrapper.
-  return;
-}
 //currently not in use, but leaving code as a claculation reference
 /*
 double[] WGS84toGoogleBing(double lon, double lat) {
@@ -101,6 +74,20 @@ function CorrectZoom (link)
 
 function add_buttons()
 {
+  if (document.getElementById('user-info') == null) {
+    setTimeout(add_buttons, 500);
+    log('user-info element not yet available, page still loading');
+    return;
+  }
+  if (!W.loginManager.user) {
+    W.loginManager.events.register('login', null, add_buttons);
+    W.loginManager.events.register('loginStatus', null, add_buttons);
+    // Double check as event might have triggered already
+    if (!W.loginManager.user) {
+      return;
+    }
+  }
+
 var btn0 = $('<button style="width: 90px;height: 24px;font-size:90%;">ß-Switch</button>');
 btn0.click(function(){
     var mapsUrl;
@@ -594,3 +581,5 @@ $("#sidepanel-p2sm").append(spacer);
 $("#sidepanel-p2sm").append(btn20); //REPORTING
 
 }
+
+add_buttons();

--- a/WME P2SM.user.js
+++ b/WME P2SM.user.js
@@ -76,7 +76,7 @@ function add_buttons()
 {
   if (document.getElementById('user-info') == null) {
     setTimeout(add_buttons, 500);
-    log('user-info element not yet available, page still loading');
+    console.log('user-info element not yet available, page still loading');
     return;
   }
   if (!W.loginManager.user) {

--- a/WME P2SM.user.js
+++ b/WME P2SM.user.js
@@ -510,6 +510,7 @@ var txtbtn3 = $('<button style="width: 285px;height: 24px; border: 1px solid sil
 var txtbtn4 = $('<button style="width: 285px;height: 24px; border: 1px solid silver; font-size:80%; font-weight: bold; color: CornflowerBlue; background-color: ghostwhite; border-radius: 7px">GEOPORTALE</button>');
 var txtbtn5 = $('<button style="width: 285px;height: 24px; border: 1px solid silver; font-size:80%; font-weight: bold; color: LightSeaGreen; background-color: ghostwhite; border-radius: 7px;">WAZE INTERN</button>');
 var spacer = '<p style="margin-bottom:10px">'
+var safeSourcesText = $('<div><i class="w-icon w-icon-warning" style="font-size: 30px;float: left;margin-right: 5px;margin-bottom: 20px;"></i> Verwenden Sie diese anderen Karten niemals als Informationsquelle, um die Karte zu bearbeiten!</div>');
 
 // add new box to left of the map
 var addon = document.createElement("section");
@@ -580,6 +581,8 @@ $("#sidepanel-p2sm").append(txtbtn5);
 $("#sidepanel-p2sm").append(spacer);
 $("#sidepanel-p2sm").append(btn20); //REPORTING
 
+$("#sidepanel-p2sm").append('<br><br>'); //SAFE SOURCES WARNING
+$("#sidepanel-p2sm").append(safeSourcesText);
 }
 
 add_buttons();


### PR DESCRIPTION
As requested, I've adjusted the bootstrap code to something more robust that should make sure the script runs as intended in the future.

I do want to stress that this sort of userscript is generally very dangerous! Waze does not have a licence to use information from most of the data sources being linked to. Using those maps as a source of information could potentially require Waze to undo a lot of changes and possibly even delete the map as a whole. In theory, it is fine to just look at other maps and find official and open sources that confirm this, but even then you're at the edge of what is legally allowed.

For that reason I've also added some text underneath that stresses that most of these maps can not legally be used for map editing.